### PR TITLE
Change the build commands to ONBUILD

### DIFF
--- a/platforms/ruby/Dockerfile.t
+++ b/platforms/ruby/Dockerfile.t
@@ -18,8 +18,8 @@ RUN echo "cd /app/src" >> /app/.profile.d/ruby.sh
 
 WORKDIR /app/src
 
-COPY . /app/src
-RUN gem install bundler
-RUN bundle install
-EXPOSE 3000
-CMD rackup -p $PORT -o 0.0.0.0
+ONBUILD COPY . /app/src
+ONBUILD RUN gem install bundler
+ONBUILD RUN bundle install
+ONBUILD EXPOSE 3000
+ONBUILD CMD rackup -p $PORT -o 0.0.0.0


### PR DESCRIPTION
It works now, previously I wasn't doing `docker:start`
that's why it wasn't working.

Some comments with this new workflow:

1) I'm not sure if you want users to do docker:start
   everytime they want to run their app, and anytime
   they change it. If that's the case, it will be very
   slow for ruby's case mostly because one change
   means re-installing the gems everytime, and that flow
   in my machine at least takes about 30-40s everytime
   I do `docker:start`.

2) I typically get around this problem with docker-compose
   by using mounted folders and whitelisting these certain
   folders per app. Not sure how to generalize that, but
   that works pretty well at least for my case.

   Start: `docker-compose start`
   Test: `docker-compose run web test`

   @see https://github.com/heroku/vacuole/blob/master/docker-compose.yml
   @see https://github.com/heroku/builds.docker
