### PR TITLE
WORKDIR should be /app/src for both exec and start

### DIFF
--- a/platforms/ruby/Dockerfile.t
+++ b/platforms/ruby/Dockerfile.t
@@ -24,8 +24,8 @@ ENV GEM_HOME=/app/src/vendor/bundle
 RUN mkdir -p /app/heroku/node
 RUN curl -s https://s3pository.heroku.com/node/v$NODE_ENGINE/node-v$NODE_ENGINE-linux-x64.tar.gz | tar --strip-components=1 -xz -C /app/heroku/node
 ENV PATH /app/heroku/node/bin:$PATH
+WORKDIR /app/src
 
-ONBUILD WORKDIR /app/src
 ONBUILD COPY Gemfile /app/src/
 ONBUILD COPY Gemfile.lock /app/src/
 


### PR DESCRIPTION
Patching ruby dockerfile for removed `-w /app/src` (https://github.com/heroku/heroku-docker/pull/61)