### PR TITLE
Scala: Removed appName var from Dockerfile

### DIFF
--- a/platforms/scala/Dockerfile.t
+++ b/platforms/scala/Dockerfile.t
@@ -6,7 +6,6 @@ WORKDIR /app
 
 ENV HOME /app
 ENV PATH /app/heroku/jdk/bin:$PATH
-ENV APP_NAME <%= app_name %>
 ENV PORT 3000
 
 RUN mkdir -p /app/heroku/jdk

--- a/platforms/scala/index.js
+++ b/platforms/scala/index.js
@@ -15,19 +15,6 @@ module.exports = {
     var templatePath = path.resolve(__dirname, 'Dockerfile.t');
     var template = fs.readFileSync(templatePath, { encoding: 'utf8' });
     var compiled = _.template(template);
-    var appName = getAppName(dir);
-    return compiled({
-      app_name: appName
-    });
+    return compiled({});
   }
 };
-
-function getAppName(dir) {
-  var f = null
-  fs.readdirSync(path.join(dir, 'target/universal/stage/bin/')).forEach(function(file) {
-    if (path.extname(file) == '') {
-      f = file;
-    }
-  });
-  return f;
-}


### PR DESCRIPTION
Removed appName var from Dockerfile. It's not needed anymore because we use the Procfile command instead of rolling our own CMD