### PR TITLE
Some additional things to skip

### DIFF
--- a/commands/release.js
+++ b/commands/release.js
@@ -112,7 +112,7 @@ function release(context) {
 
       function tar(imageId) {
         cli.log('extracting slug from container...');
-        var containerId = child.execSync(`docker run -d ${imageId} tar cfvz /tmp/slug.tgz -C / --exclude=.git ./app`, {
+        var containerId = child.execSync(`docker run -d ${imageId} tar cfvz /tmp/slug.tgz -C / --exclude=.git --exclude=.cache --exclude=.buildpack ./app`, {
           encoding: 'utf8'
         }).trim();
         child.execSync(`docker wait ${containerId}`);


### PR DESCRIPTION
I am using a slightly modified version of the go buildpack now and what
they need should not be part of the slug