### PR TITLE
always try and rebuild image

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -69,7 +69,7 @@ function ensureExecImage(dir) {
     var contents = fs.readFileSync(dockerfile, { encoding: 'utf8' });
     var hash = createHash(contents);
     var imageId = getImageId(hash);
-    this.imageExists(imageId) || this.buildImage(dir, imageId);
+    this.buildImage(dir, imageId);
     return imageId;
   }
   catch (e) {


### PR DESCRIPTION
Previously, if local code changed but not the Dockerfile, release
wouldn't actually release your new code, which was a serious bug. This
fixes that by making it always run "build", and relying on Docker
caching to only change the things that need to change.