### PR TITLE
Adds addon env to addon image

### DIFF
--- a/commands/init.js
+++ b/commands/init.js
@@ -138,7 +138,8 @@ function createDockerCompose(procfile, addons, mountDir) {
 
   function addonToService(addon) {
     return {
-      image: ADDONS[addon].image
+      image: ADDONS[addon].image,
+      environment: ADDONS[addon].env
     };
   }
 }


### PR DESCRIPTION
Some addons need env vars on their own image too, to run independently. An example is mysql, which needs at least MYSQL_ROOT_PASSWORD on its on image, see: https://github.com/docker-library/docs/tree/master/mysql#environment-variables

This fix adds the addon env vars to the addon image, fixing this