### PR TITLE
Adds cleardb addon support, closing issue #126

### DIFF
--- a/lib/addons.js
+++ b/lib/addons.js
@@ -18,5 +18,13 @@ module.exports = {
   'memcachedcloud': {
     image: 'memcached',
     env: { 'MEMCACHEDCLOUD_SERVERS': 'memcachedcloud:11211' }
+  },
+  'cleardb': {
+    image: 'mysql',
+    env: {
+      'MYSQL_DATABASE': 'cleardb',
+      'MYSQL_ROOT_PASSWORD': 'my-secret-pw',
+      'CLEARDB_DATABASE_URL': 'mysql://root:my-secret-pw@cleardb:3306/cleardb'
+    }
   }
 };

--- a/lib/addons.js
+++ b/lib/addons.js
@@ -23,8 +23,8 @@ module.exports = {
     image: 'mysql',
     env: {
       'MYSQL_DATABASE': 'cleardb',
-      'MYSQL_ROOT_PASSWORD': 'my-secret-pw',
-      'CLEARDB_DATABASE_URL': 'mysql://root:my-secret-pw@cleardb:3306/cleardb'
+      'MYSQL_ALLOW_EMPTY_PASSWORD': 'yes',
+      'CLEARDB_DATABASE_URL': 'mysql://root:@cleardb:3306/cleardb'
     }
   }
 };


### PR DESCRIPTION
Adds cleardb addon support, but is blocked by PR #129 for MySQL env var support. This fixes issue #126. Tested locally and on Heroku, works nice.