### PR TITLE
Use posix path for mount directories

### DIFF
--- a/commands/init.js
+++ b/commands/init.js
@@ -79,7 +79,7 @@ function createDockerfile(image) {
 }
 
 function createDockerCompose(procfile, addons, mountDir) {
-  var volumeMount = path.join('/app/user', mountDir || '');
+  var volumeMount = path.posix.join('/app/user', mountDir || '');
 
   // get the base addon name, ignoring plan types
   var addonNames = _.map(addons, nameWithoutPlan);

--- a/lib/directory.js
+++ b/lib/directory.js
@@ -18,5 +18,5 @@ function readProcfile(cwd) {
 
 function determineMountDir(dir) {
   var appJSON = JSON.parse(fs.readFileSync(path.join(dir, 'app.json'), { encoding: 'utf8' }));
-  return path.join('/app/user', appJSON.mount_dir || '');
+  return path.posix.join('/app/user', appJSON.mount_dir || '');
 }


### PR DESCRIPTION
Since `path.join('/app/user', '')` returns `'\app\user'` on Windows.
