### PR TITLE
Add --dockerfile flag to use existing Dockerfile

### DIFF
--- a/test/init.test.js
+++ b/test/init.test.js
@@ -142,6 +142,18 @@ describe('init', function() {
         assert.equal(test.diff('with-force'), '[]');
       });
     });
+
+    describe('with the --dockerfile flag', function() {
+      it('keeps Dockerfile', function() {
+        var test = fixture('has-dockerfile');
+        init.run({
+          debug: true,
+          cwd: test.cwd,
+          flags: { dockerfile: 'Dockerfile' }
+        });
+        assert.equal(test.diff('with-force'), '[]');
+      });
+    });
   });
 
   describe('with existing docker-compose.yml', function() {


### PR DESCRIPTION
This allows for the `docker-compose.yml` to be (re)generated without destroying a customized `Dockerfile`. It also makes it possible to use an existing `Dockerfile` template.

## Usage

```
$ heroku docker:init --dockerfile Dockerfile
```

## Future work

It would also be desirable for the "image" property to be derived from the `FROM` directive in the existing `Dockerfile` if provided. That can 