### PR TITLE
docker:login and docker:push with the new docker runtime/registry

### DIFF
--- a/commands/login.js
+++ b/commands/login.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const cli = require('heroku-cli-util');
+const co = require('co');
+const child = require('child_process');
+
+module.exports = function(topic) {
+  return {
+    topic: topic,
+    command: 'login',
+    description: 'Logs in to the Heroku Docker registry',
+    needsApp: false,
+    needsAuth: true,
+    run: cli.command(co.wrap(login))
+  };
+};
+
+function* login(context, heroku) {
+  let herokuHost = process.env.HEROKU_HOST || 'heroku.com';
+  let registry = `registry.${ herokuHost }`;
+  let password = context.auth.password;
+
+  try {
+    let user = yield dockerLogin(registry, password);
+  }
+  catch (err) {
+    cli.error(`Error: docker login exited with ${ err }`);
+  }
+}
+
+function dockerLogin(registry, password) {
+  return new Promise((resolve, reject) => {
+    let args = [
+      'login',
+      '--email=_',
+      '--username=_',
+      `--password=${ password }`,
+      registry
+    ];
+    child.spawn('docker', args, { stdio: 'inherit' })
+      .on('exit', (code, signal) => {
+        if (signal || code) reject(signal || code);
+        else resolve();
+      });
+  });
+}

--- a/commands/push.js
+++ b/commands/push.js
@@ -8,18 +8,17 @@ module.exports = function(topic) {
   return {
     topic: topic,
     command: 'push',
-    description: 'Deploys a Docker image to your Heroku app',
+    description: 'Builds, then pushes a Docker image to deploy your Heroku app',
     needsApp: true,
     needsAuth: true,
     args: [{ name: 'process', optional: true }],
-    run: cli.command(co.wrap(release))
+    run: cli.command(co.wrap(push))
   };
 };
 
-function* release(context, heroku) {
+function* push(context, heroku) {
   let herokuHost = process.env.HEROKU_HOST || 'heroku.com';
   let registry = `registry.${ herokuHost }`;
-  let password = context.auth.password;
   let proc = context.args.process || 'web';
   let resource = `${ registry }/${ context.app }/${ proc }`;
 

--- a/commands/push.js
+++ b/commands/push.js
@@ -1,0 +1,71 @@
+'use strict';
+
+const cli = require('heroku-cli-util');
+const co = require('co');
+const child = require('child_process');
+
+module.exports = function(topic) {
+  return {
+    topic: topic,
+    command: 'push',
+    description: 'Deploys a Docker image to your Heroku app',
+    needsApp: true,
+    needsAuth: true,
+    args: [{ name: 'process', optional: true }],
+    run: cli.command(co.wrap(release))
+  };
+};
+
+function* release(context, heroku) {
+  let herokuHost = process.env.HEROKU_HOST || 'heroku.com';
+  let registry = `registry.${ herokuHost }`;
+  let password = context.auth.password;
+  let proc = context.args.process || 'web';
+  let resource = `${ registry }/${ context.app }/${ proc }`;
+
+  try {
+    let build = yield buildImage(resource, context.cwd);
+  }
+  catch (err) {
+    cli.error(`Error: docker build exited with ${ err }`);
+    process.exit(1);
+  }
+
+  try {
+    let push = yield pushImage(resource);
+  }
+  catch (err) {
+    cli.error(`Error: docker push exited with ${ err }`);
+    process.exit(1);
+  }
+}
+
+function buildImage(resource, cwd) {
+  return new Promise((resolve, reject) => {
+    let args = [
+      'build',
+      '-t',
+      resource,
+      cwd
+    ];
+    child.spawn('docker', args, { stdio: 'inherit' })
+      .on('exit', (code, signal) => {
+        if (signal || code) reject(signal || code);
+        else resolve();
+      });
+  });
+}
+
+function pushImage(resource) {
+  return new Promise((resolve, reject) => {
+    let args = [
+      'push',
+      resource
+    ];
+    child.spawn('docker', args, { stdio: 'inherit' })
+      .on('exit', (code, signal) => {
+        if (signal || code) reject(signal || code);
+        else resolve();
+      });
+  });
+}

--- a/commands/release.js
+++ b/commands/release.js
@@ -110,7 +110,11 @@ function release(context) {
       }
 
       function onBuildExit(code) {
-        if (code !== 0) throw new Error('Build failed');
+        if (code !== 0) {
+          cli.log('Build failed. Make sure `docker-compose build web` returns a 0 exit status.');
+          process.exit(1);
+        }
+
         var tokens = output.match(/\S+/g);
         var fromMatch = output.match(/FROM ([^\s]+)/) || [];
         var imageName = fromMatch[1];

--- a/index.js
+++ b/index.js
@@ -4,6 +4,8 @@ module.exports = {
   commands: [
     require('./commands/index')(pkg),
     require('./commands/init')(pkg.topic),
-    require('./commands/release')(pkg.topic)
+    require('./commands/release')(pkg.topic),
+    require('./commands/login')(pkg.topic),
+    require('./commands/push')(pkg.topic)
   ]
 };

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "license": "ISC",
   "dependencies": {
     "camelcase": "1.0.2",
-    "co": "^4.6.0",
+    "co": "4.6.0",
     "dotenv": "^1.1.0",
     "heroku-cli-util": "^1.8.1",
     "heroku-client": "^1.9.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "license": "ISC",
   "dependencies": {
     "camelcase": "1.0.2",
+    "co": "^4.6.0",
     "dotenv": "^1.1.0",
     "heroku-cli-util": "^1.8.1",
     "heroku-client": "^1.9.1",
@@ -32,11 +33,11 @@
     "yamljs": "0.2.4"
   },
   "devDependencies": {
-    "chai": "3.2.0",
-    "depcheck": "0.4.7",
-    "dir-compare": "0.0.2",
-    "fs-extra": "0.23.1",
+    "chai": "^3.2.0",
+    "depcheck": "^0.4.7",
+    "dir-compare": "^0.0.2",
+    "fs-extra": "^0.23.1",
     "mocha": "^2.2.4",
-    "wrench": "1.5.8"
+    "wrench": "^1.5.8"
   }
 }


### PR DESCRIPTION
Adds two commands for our new docker runtime and registry:

- `heroku docker:login`
- `heroku docker:push`

To test:

- `heroku sudo labs:enable docker-releases` (flag yourself into the docker runtime)
- clone, checkout this branch
- from within this repo's dir, `heroku plugins:link` (tell the cli to symlink a local plugin)
- cd into a directory with a (not important) Dockerfile, an app, and a git repo
- `git remote rm heroku` (disconnect any existing heroku app)
- `heroku create`
- `heroku docker:login`
- `heroku docker:push`
- `heroku open`

Notes and details:

- https://gist.github.com/tt/b81be8de690441a791bdfe507f947954